### PR TITLE
Fixes `python-version` for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
         poetry-version: [latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,36 @@ multi_line_output = 3
 
 [tool.mypy]
 ignore_missing_imports = true
+
+
+## COVERAGE ##
+
+[tool.coverage.paths]
+source = ["src", "*/site-packages"]
+
+[tool.coverage.run]
+branch = true
+source = ["maldi_tools"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "except ImportError",
+    "raise AssertionError",
+    "raise NotImplementedError",
+]
+
+show_missing = true
+ignore_errors = false
+fail_under = 0
+omit = ["**/*test*.py"]
+
+## TESTING ##
+
+[tool.pytest.ini_options]
+addopts = ["-vv", "-s", "--cov", "--pycodestyle", "--cov-report=lcov"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning",
+]
+testpaths = ["tests"]
+norecursedirs = ["tests/utilities"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[pycodestyle]
+count = False
+ignore = E226,E401
+max-line-length = 110
+statistics = True


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Fixes a `python-version` issue, where `3.10` gets cut to `3.1`. Instead place quotation marks around it `"3.10"`.

**How did you implement your changes**

Adjusted `3.10` to `"3.10"`.

**Remaining issues**

N/A