### PR TITLE
Remove Depencence on scanSettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ cython_debug/
 .vscode
 .python-version
 .ruff_cache
+coverage.lcov

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -252,8 +252,8 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser) -> xr.D
 
     imz_coordinates: list = imz_data.coordinates
 
-    x_size: int = max(imz_coordinates, key=itemgetter(0))
-    y_size: int = max(imz_coordinates, key=itemgetter(1))
+    x_size: int = max(imz_coordinates, key=itemgetter(0))[0]
+    y_size: int = max(imz_coordinates, key=itemgetter(1))[1]
 
     image_shape: Tuple[int, int] = (x_size, y_size)
 

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -43,8 +43,6 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
     x_size: int = max(imz_coordinates, key=itemgetter(0))[0]
     y_size: int = max(imz_coordinates, key=itemgetter(1))[1]
 
-    print(x_size, y_size)
-
     image_shape: Tuple[int, int] = (x_size, y_size)
 
     thresholds: np.ndarray = np.zeros(image_shape)

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -29,7 +29,6 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from pyimzml.ImzMLParser import ImzMLParser\n",
-    "import xarray as xr\n",
     "from maldi_tools import extraction, plotting"
    ]
   },

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -65,10 +65,9 @@ def total_mass_df(rng: np.random.Generator) -> pd.DataFrame:
 
 def test_extract_spectra(imz_data: ImzMLParser) -> None:
     intensity_percentile: int = 99
-    scan_setting: str = "scanSettings1"
 
     total_mass_df, thresholds = extraction.extract_spectra(
-        imz_data=imz_data, intensity_percentile=intensity_percentile, scan_setting=scan_setting
+        imz_data=imz_data, intensity_percentile=intensity_percentile
     )
 
     assert thresholds.shape == (10, 10)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Removed getting image dimensions from `"scanSettings"` which is rather fickle to deal with.

**How did you implement your changes**

Grabbed the dimensions of the image from the coordinates of `imzML` file.

**Remaining issues**

N/A