### PR TITLE
Remove `--user` install flag for `pip` installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,5 @@ dependencies:
   - scikit-image
   - matplotlib
   - pip:
-    - alpineer --user
-    - . --user
+    - alpineer
+    - .


### PR DESCRIPTION
**What is the purpose of this PR?**

The `--user` flag is no longer supported in the `environment.yml` file. Remove to install correctly.

**How did you implement your changes**

Remove `--user`.

**Remaining issues**

Not sure if this will work on the MALDI computers. I know we needed to use `--user` to `pip` install `toffy` on the MIBI CACs.