### PR TITLE
Bin data extracted from TIMSCONVERT in MALDI notebook

### DIFF
--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -82,7 +82,6 @@ def extract_spectra(
 
     thresholds: np.ndarray = np.zeros(image_shape)
     total_spectra: Dict[float, float] = {}
-
     mz_bins: np.ndarray = generate_mz_bins(min_mz, max_mz)
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_coordinates)):

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -1,6 +1,8 @@
 """Used for extracting spectra data, filtering intensities and masses, and matching the discovered m/z peaks
 to the user supplied library.
 
+NOTE: this workflow will most likely be deprecated in favor of the pyTDFSDK workflow
+
 - TODO: Parallel spectra extraction
 - TODO: Adduct matching
 

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -63,6 +63,30 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
     return (total_mass_df, thresholds)
 
 
+def bin_spectra(total_mass_df: pd.DataFrame, precision: int = 3):
+    """Bins the spectra in a similar manner as SciLS does on their backend.
+
+    NOTE: the result will not exactly match, but will provide a similar level of granularity.
+
+    Args:
+    ----
+        total_mass_df (pd.DataFrame): A dataframe containing all the masses and their relative intensities.
+
+    Returns:
+        pd.DataFrame: the spectra data assigned to m/z bins
+    """
+    total_mass_df_binned = total_mass_df.copy()
+    total_mass_df_binned["m/z_binned"] = (total_mass_df_binned["m/z"] * 10**precision).round() / (
+        10**precision
+    )
+    intensity_aggregated = total_mass_df_binned.groupby("m/z_binned")["intensity"].sum().reset_index()
+    total_mass_df_binned = pd.DataFrame(
+        {"m/z": intensity_aggregated["m/z_binned"], "intensity": intensity_aggregated["intensity"]}
+    )
+
+    return total_mass_df_binned
+
+
 def rolling_window(
     total_mass_df: pd.DataFrame, intensity_percentile: int, window_size: int = 5000
 ) -> tuple[np.ndarray, np.ndarray]:

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -212,6 +212,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total_mass_df = extraction.bin_spectra(total_mass_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -598,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -212,15 +212,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "total_mass_df = extraction.bin_spectra(total_mass_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "tags": []
    },

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -16,7 +16,7 @@ def test_extract_spectra(imz_data: ImzMLParser) -> None:
     intensity_percentile: int = 99
 
     total_mass_df, thresholds = extraction.extract_spectra(
-        imz_data=imz_data, intensity_percentile=intensity_percentile
+        imz_data=imz_data, intensity_percentile=intensity_percentile, min_mz=3000, max_mz=10000
     )
 
     assert thresholds.shape == (10, 10)


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #14. The `.imzml` data extracted from TIMSCONVERT does not do spectra binning as SciLS does on their backend, so we replicate it the best we can.

**How did you implement your changes**

Add a function `bin_spectra` to `extraction.py` which accomplishes this.

**Remaining issues**

Testing needed.