### PR TITLE
Ensure library matching uses the mass with the lowest mass error in case of ties

### DIFF
--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -185,7 +185,6 @@ def test_map_coordinates_to_core_name(
 def test_map_coordinates_to_core_name_malformed(
     imz_data: ImzMLParser, bad_centroid_path: pathlib.Path, poslog_dir: pathlib.Path
 ):
-    print(bad_centroid_path)
     poslog_paths: List[pathlib.Path] = [poslog_dir / pf for pf in os.listdir(poslog_dir)]
     with pytest.warns(match="Could not find mapping of core Region0"):
         extraction.map_coordinates_to_core_name(imz_data, bad_centroid_path, poslog_paths)


### PR DESCRIPTION
**What is the purpose of this PR?**

The `_matching_vec` helper function for `library_matching` previously assumed that there would only be one instance of a matching mass, so it took the first one every time. That can no longer be assumed: we will need to find the mass with the lowest mass error relative to `ppm` since there could be multiple masses.

**How did you implement your changes**

Implement an additional control flow that iterates through each mass and finds the minimum across all masses in `library_peak_df`.

**Remaining issues**

This is inherently a slower implementation since matches will take as long as non-matches. To speed this up, potentially iterate through a pre-sorted `library_peak_df` by `m/z` value.