### PR TITLE
Change coordinate integration from raw intensity to area under the curve

### DIFF
--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -233,7 +233,6 @@ def peak_spectra(
 
 
 def coordinate_integration(
-    total_mass_df: pd.DataFrame,
     peak_df: pd.DataFrame,
     l_ips_r: np.ndarray,
     r_ips_r: np.ndarray,
@@ -271,13 +270,11 @@ def coordinate_integration(
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_data.coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)
 
-        intensities[np.isin(mzs, peak_df["m/z"])]
-
         for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
-            left_idx = abs(total_mass_df.values - l_ips_r[i_idx]).idxmin()
-            right_idx = abs(total_mass_df.values - r_ips_r[i_idx]).idxmin()
+            left_idx = abs(intensities.values - l_ips_r[i_idx]).idxmin()
+            right_idx = abs(intensities.values - r_ips_r[i_idx]).idxmin()
             imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(
-                total_mass_df.values[left_idx:right_idx]
+                intensities.values[left_idx:right_idx]
             ) - (peak_widths_height * (right_idx - left_idx))
 
     img_data = xr.DataArray(

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -271,11 +271,11 @@ def coordinate_integration(
         mzs, intensities = imz_data.getspectrum(idx)
 
         for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
-            left_idx = abs(intensities.values - l_ips_r[i_idx]).idxmin()
-            right_idx = abs(intensities.values - r_ips_r[i_idx]).idxmin()
-            imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(
-                intensities.values[left_idx:right_idx]
-            ) - (peak_widths_height * (right_idx - left_idx))
+            left_idx = abs(intensities - l_ips_r[i_idx]).idxmin()
+            right_idx = abs(intensities - r_ips_r[i_idx]).idxmin()
+            imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(intensities[left_idx:right_idx]) - (
+                peak_widths_height * (right_idx - left_idx)
+            )
 
     img_data = xr.DataArray(
         data=imgs,

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -325,11 +325,13 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser) -> xr.D
         for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
             imgs[peak_dict[peak], x - 1, y - 1] += intensity[i_idx]
 
-    xr.DataArray(
+    img_data = xr.DataArray(
         data=imgs,
         coords={"peak": unique_peaks, "x": range(x_size), "y": range(y_size)},
         dims=["peak", "x", "y"],
     )
+
+    return img_data
 
 
 def _matching_vec(obs_mz: pd.Series, library_peak_df: pd.DataFrame, ppm: int) -> pd.Series:

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -232,8 +232,10 @@ def peak_spectra(
     return panel_df
 
 
-def coordinate_integration(
+def coordinate_integration_aoc(
+    total_mass_df: pd.DataFrame,
     peak_df: pd.DataFrame,
+    peak_candidates: np.ndarray,
     l_ips_r: np.ndarray,
     r_ips_r: np.ndarray,
     peak_widths_height: np.ndarray,
@@ -270,12 +272,16 @@ def coordinate_integration(
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_data.coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)
 
-        for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
-            left_idx = np.argmin(abs(intensities - l_ips_r[i_idx]))
-            right_idx = np.argmin(abs(intensities - r_ips_r[i_idx]))
-            imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(intensities[left_idx:right_idx]) - (
-                peak_widths_height[i_idx] * (right_idx - left_idx)
-            )
+        for peak_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
+            if peak in mzs:  # may be redundant
+                peak_idx = np.where(peak_candidates == peak)[0][0]
+                left_idx = l_ips_r[peak_idx]
+                right_idx = r_ips_r[peak_idx] + 1
+                peak_widths_height[peak_idx]
+
+                imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(
+                    total_mass_df.intensity.values[left_idx:right_idx]
+                )
 
     img_data = xr.DataArray(
         data=imgs,
@@ -284,6 +290,46 @@ def coordinate_integration(
     )
 
     return img_data
+
+
+def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser) -> xr.DataArray:
+    """Integrates the coordinates with the discovered, post-processed peaks and generates an image for
+    each of the peaks using the imzML coordinate data.
+
+    Args:
+    ----
+        peak_df (pd.DataFrame): The unique peaks from the data.
+        imz_data (ImzMLParser): The imzML object.
+
+    Returns:
+    -------
+        xr.DataArray: A data structure which holds all the images for each peak.
+    """
+    unique_peaks = peak_df["peak"].unique()
+    peak_dict = dict(zip(unique_peaks, np.arange((len(unique_peaks)))))
+
+    imz_coordinates: list = imz_data.coordinates
+
+    x_size: int = max(imz_coordinates, key=itemgetter(0))[0]
+    y_size: int = max(imz_coordinates, key=itemgetter(1))[1]
+
+    image_shape: Tuple[int, int] = (x_size, y_size)
+
+    imgs = np.zeros((len(unique_peaks), *image_shape), dtype=np.float32)
+
+    for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_data.coordinates)):
+        mzs, intensities = imz_data.getspectrum(idx)
+
+        intensity: np.ndarray = intensities[np.isin(mzs, peak_df["m/z"])]
+
+        for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
+            imgs[peak_dict[peak], x - 1, y - 1] += intensity[i_idx]
+
+    xr.DataArray(
+        data=imgs,
+        coords={"peak": unique_peaks, "x": range(x_size), "y": range(y_size)},
+        dims=["peak", "x", "y"],
+    )
 
 
 def _matching_vec(obs_mz: pd.Series, library_peak_df: pd.DataFrame, ppm: int) -> pd.Series:

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -53,7 +53,7 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
         mzs, intensities = imz_data.getspectrum(idx)
         for mass_idx, mz in enumerate(mzs):
             total_spectra[mz] = (0 if mz not in total_spectra else total_spectra[mz]) + intensities[mass_idx]
-            count_spectra[mz] = (0 if mz not in total_spectra else count_spectra[mz]) + 1
+            count_spectra[mz] = (0 if mz not in count_spectra else count_spectra[mz]) + 1
 
         thresholds[x - 1, y - 1] = np.percentile(intensities, intensity_percentile)
 

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -47,15 +47,18 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
 
     thresholds: np.ndarray = np.zeros(image_shape)
     total_spectra: Dict[float, float] = {}
+    count_spectra: Dict[float, int] = {}
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)
         for mass_idx, mz in enumerate(mzs):
             total_spectra[mz] = (0 if mz not in total_spectra else total_spectra[mz]) + intensities[mass_idx]
+            count_spectra[mz] = (0 if mz not in total_spectra else count_spectra[mz]) + 1
 
         thresholds[x - 1, y - 1] = np.percentile(intensities, intensity_percentile)
 
-    total_mass_df = pd.DataFrame(total_spectra.items(), columns=["m/z", "intensity"])
+    avg_spectra: Dict[float, float] = {mz: total_spectra[mz] / count_spectra[mz] for mz in total_spectra}
+    total_mass_df = pd.DataFrame(avg_spectra.items(), columns=["m/z", "intensity"])
 
     total_mass_df.sort_values(by="m/z", inplace=True)
     total_mass_df.reset_index(drop=True, inplace=True)

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -271,10 +271,10 @@ def coordinate_integration(
         mzs, intensities = imz_data.getspectrum(idx)
 
         for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
-            left_idx = abs(intensities - l_ips_r[i_idx]).idxmin()
-            right_idx = abs(intensities - r_ips_r[i_idx]).idxmin()
+            left_idx = np.argmin(abs(intensities - l_ips_r[i_idx]))
+            right_idx = np.argmin(abs(intensities - r_ips_r[i_idx]))
             imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(intensities[left_idx:right_idx]) - (
-                peak_widths_height * (right_idx - left_idx)
+                peak_widths_height[i_idx] * (right_idx - left_idx)
             )
 
     img_data = xr.DataArray(

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -47,18 +47,15 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
 
     thresholds: np.ndarray = np.zeros(image_shape)
     total_spectra: Dict[float, float] = {}
-    count_spectra: Dict[float, int] = {}
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)
         for mass_idx, mz in enumerate(mzs):
             total_spectra[mz] = (0 if mz not in total_spectra else total_spectra[mz]) + intensities[mass_idx]
-            count_spectra[mz] = (0 if mz not in count_spectra else count_spectra[mz]) + 1
 
         thresholds[x - 1, y - 1] = np.percentile(intensities, intensity_percentile)
 
-    avg_spectra: Dict[float, float] = {mz: total_spectra[mz] / count_spectra[mz] for mz in total_spectra}
-    total_mass_df = pd.DataFrame(avg_spectra.items(), columns=["m/z", "intensity"])
+    total_mass_df = pd.DataFrame(total_spectra.items(), columns=["m/z", "intensity"])
 
     total_mass_df.sort_values(by="m/z", inplace=True)
     total_mass_df.reset_index(drop=True, inplace=True)
@@ -277,14 +274,17 @@ def coordinate_integration_aoc(
 
         for peak_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
             if peak in mzs:  # may be redundant
+                mz_idx = mzs.where(mzs == peak)[0][0]
                 peak_idx = np.where(peak_candidates == peak)[0][0]
+
                 left_idx = l_ips_r[peak_idx]
                 right_idx = r_ips_r[peak_idx] + 1
-                peak_widths_height[peak_idx]
 
-                imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(
-                    total_mass_df.intensity.values[left_idx:right_idx]
-                )
+                peak_width = right_idx - left_idx
+                left_bound = max(mz_idx - peak_width / 2, 0)
+                right_bound = min(mz_idx + peak_width / 2, len(mzs))
+
+                imgs[peak_dict[peak], x - 1, y - 1] += integrate.simpson(mzs[left_bound:right_bound])
 
     img_data = xr.DataArray(
         data=imgs,

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -466,7 +466,13 @@
    },
    "outputs": [],
    "source": [
-    "image_data = extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data)"
+    "image_data = extraction.coordinate_integration(\n",
+    "    peak_df=peak_df,\n",
+    "    l_ips_r=l_ips_r,\n",
+    "    r_ips_r=r_ips_r,\n",
+    "    peak_widths_height=peak_widths_height,\n",
+    "    imz_data=imz_data,\n",
+    ")"
    ]
   },
   {
@@ -598,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -478,12 +478,45 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO: new AOC coordinate integration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_data_aoc = extraction.coordinate_integration_aoc(\n",
+    "    total_mass_df=total_mass_df,\n",
+    "    peak_df=peak_df,\n",
+    "    peak_candidates=peak_candidates,\n",
+    "    l_ips_r=l_ips_r,\n",
+    "    r_ips_r=r_ips_r,\n",
+    "    peak_widths_height=peak_widths_height,\n",
+    "    imz_data=imz_data,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "image_data"
+    "image_data_aoc"
    ]
   },
   {
@@ -604,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.11"
   },
   "vscode": {
    "interpreter": {

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -97,7 +97,16 @@ def test_peak_spectra(
 
 def test_coordinate_integration(imz_data, peak_widths):
     peak_df, *_ = peak_widths
-    img_data = extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data)
+    l_ips_r = np.arange(0, peak_df.shape[0], 5)
+    r_ips_r = l_ips_r + 2
+    peak_widths_height = np.repeat(2, peak_df.shape[0])
+    img_data = extraction.coordinate_integration(
+        peak_df=peak_df,
+        l_ips_r=l_ips_r,
+        r_ips_r=r_ips_r,
+        peak_widths_height=peak_widths_height,
+        imz_data=imz_data,
+    )
 
     # Make sure the shape of any given image is correct.
     assert img_data.shape[1:] == (10, 10)


### PR DESCRIPTION
**What is the purpose of this PR?**

When writing out the peak image, the raw peak intensity at each spot is currently used. The agreed upon practice is to use the area under this curve from the peak base, so this needs to be updated.

**How did you implement your changes**

In order to properly calculate this area, the `l_ips_r` (left bound of peak), `r_ips_r` (right bound of peak), and `peak_widths_height` (height at which peak base begins) needs to be passed into `coordinate_integration`.

Find the closest value in the spot spectra that matches up with the m/z values associated with the corresponding `l_ips_r` and `r_ips_r`, then use those indices as the bounds for integrating the signal at the spot. Integration is done using `scipy.integrate.simpson`.

Because the peak only begins at 10% higher than the peak's prominence, the bottom rectangle below this must be subtracted out. This area to be removed can be computed using the corresponding `peak_widths_height` and the base length defined by subtracting the corresponding `l_ips_r` from `r_ips_r`.

**Remaining issues**

The peaks are currently determined across all spots. However, integration needs to be done on a spot level. While it is assumed that peaks at a spot level correspond to peaks across all spots, we have no way of knowing for sure. If this isn't the case, integration for peaks could be wrong because the actual peak interval for spots aren't getting captured.

This PR may also need to change if the raw glycan list is used instead of the existing peak finding/filtering algorithm.