### PR TITLE
Ensure memory efficiency when working with peak images

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -87,10 +87,7 @@ def imz_data_coord_int(tmp_path_factory: TempPathFactory, rng: np.random.Generat
 def total_mass_df(rng: np.random.Generator) -> pd.DataFrame:
     mz_count: int = 10000
     df = pd.DataFrame(
-        data={
-            "m/z": np.linspace(start=1, stop=101, num=mz_count),
-            "intensity": rng.random(size=mz_count)
-        }
+        data={"m/z": np.linspace(start=1, stop=101, num=mz_count), "intensity": rng.random(size=mz_count)}
     )
     yield df
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,7 @@
 import json
 import os
 from pathlib import Path
-from typing import Generator, List
+from typing import Generator, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -54,10 +54,43 @@ def imz_data(tmp_path_factory: TempPathFactory, rng: np.random.Generator) -> Imz
 
 
 @pytest.fixture(scope="session")
+def imz_data_coord_int(tmp_path_factory: TempPathFactory, rng: np.random.Generator) -> ImzMLParser:
+    # Simplify the previous process for a single coordinate image (1x1)
+    img_dim: int = 1
+
+    # Generate random integers n for each coordinate (1 x 1). These will be used for creating
+    # random m/z and intensity values of length n.
+    # Lengths n are distributed along the standard gamma.
+    ns: np.ndarray = np.rint(rng.standard_gamma(shape=2.5, size=(img_dim**2)) * 100).astype(int)
+
+    # Generate random masses and sample different amounts of them, so we get duplicates
+    total_mzs: np.ndarray = (10000 - 100) * rng.random(size=img_dim**2 * 2) + 100
+
+    coords = [(x, y, 1) for x in range(1, img_dim + 1) for y in range(1, img_dim + 1)]
+
+    output_file_name: Path = tmp_path_factory.mktemp("data") / "test_data.imzML"
+
+    with ImzMLWriter(output_filename=output_file_name, mode="processed") as imzml:
+        for coord, n in zip(coords, ns):
+            # Masses: 100 <= mz < 10000, of length n, sampled randomly
+            mzs = rng.choice(a=total_mzs, size=n)
+
+            # Intensities: 0 <= int < 1e8, of length n
+            ints: np.ndarray = rng.exponential(size=n)
+
+            imzml.addSpectrum(mzs=mzs, intensities=ints, coords=coord)
+
+    yield ImzMLParser(filename=output_file_name)
+
+
+@pytest.fixture(scope="session")
 def total_mass_df(rng: np.random.Generator) -> pd.DataFrame:
     mz_count: int = 10000
     df = pd.DataFrame(
-        data={"m/z": np.linspace(start=1, stop=101, num=mz_count), "intensity": rng.random(size=mz_count)}
+        data={
+            "m/z": np.linspace(start=1, stop=101, num=mz_count),
+            "intensity": rng.random(size=mz_count)
+        }
     )
     yield df
 
@@ -75,8 +108,8 @@ def percentile_intensities(
 
 @pytest.fixture(scope="session")
 def peak_idx_candidates(
-    total_mass_df: pd.DataFrame, percentile_intensities: tuple[np.ndarray, np.ndarray]
-) -> Generator[tuple[np.ndarray, np.ndarray], None, None]:
+    total_mass_df: pd.DataFrame, percentile_intensities: Tuple[np.ndarray, np.ndarray]
+) -> Generator[Tuple[np.ndarray, np.ndarray], None, None]:
     _, log_int_percentile = percentile_intensities
 
     peak_candidate_indexes, peak_candidates = extraction.signal_extraction(
@@ -87,8 +120,8 @@ def peak_idx_candidates(
 
 @pytest.fixture(scope="session")
 def peak_widths(
-    total_mass_df, peak_idx_candidates
-) -> Generator[tuple[pd.DataFrame, np.ndarray, np.ndarray, np.ndarray], None, None]:
+    total_mass_df: pd.DataFrame, peak_idx_candidates: Tuple[np.ndarray, np.ndarray]
+) -> Generator[Tuple[pd.DataFrame, np.ndarray, np.ndarray, np.ndarray], None, None]:
     peak_candidate_idxs, peak_candidates = peak_idx_candidates
     peak_df, l_ips_r, r_ips_r, peak_widths_height = extraction.get_peak_widths(
         total_mass_df=total_mass_df,
@@ -98,6 +131,16 @@ def peak_widths(
     )
 
     yield (peak_df, l_ips_r, r_ips_r, peak_widths_height)
+
+
+@pytest.fixture(scope="session")
+def peak_widths_coord_int(imz_data_coord_int: ImzMLParser):
+    mzs, intensities = imz_data_coord_int.getspectrum(0)
+    peak_df = pd.DataFrame({"m/z": mzs, "intensity": intensities})
+    peak_df["peak"] = (peak_df["m/z"] + 0.04).copy()
+    peak_df["peak_height"] = 0.001
+
+    yield peak_df
 
 
 @pytest.fixture(scope="session")

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -16,7 +16,6 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 from alpineer.image_utils import save_image
 from alpineer.io_utils import list_files, remove_file_extensions, validate_paths
 from alpineer.misc_utils import verify_in_list
@@ -334,8 +333,7 @@ def library_matching(
         or not, the composition name and the mass error if a match was found or not.
     """
     peak_list: List[float] = [
-        float(p.replace("_", "."))
-        for p in remove_file_extensions(list_files(extraction_dir / "float"))
+        float(p.replace("_", ".")) for p in remove_file_extensions(list_files(extraction_dir / "float"))
     ]
     peak_df = pd.DataFrame({"peak": np.array(peak_list)})
     match_fun = partial(_matching_vec, library_peak_df=library_peak_df, ppm=ppm)

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -337,7 +337,7 @@ def library_matching(
         or not, the composition name and the mass error if a match was found or not.
     """
     peak_list: List[float] = [
-        float(p.replace("_", ".")) for p in remove_file_extensions(list_files(extraction_dir / "float"))
+        float(p.replace("_", ".")) for p in remove_file_extensions(list_files(Path(extraction_dir) / "float"))
     ]
     peak_df = pd.DataFrame({"peak": np.array(peak_list)})
     match_fun = partial(_matching_vec, library_peak_df=library_peak_df, ppm=ppm)

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -262,10 +262,9 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser, extract
 
     float_peak_dir: Path = Path(extraction_dir) / "float"
     int_peak_dir: Path = Path(extraction_dir) / "int"
-    if not os.path.exists(float_peak_dir):
-        os.makedirs(float_peak_dir)
-    if not os.path.exists(int_peak_dir):
-        os.makedirs(int_peak_dir)
+    for img_dir in [float_peak_dir, int_peak_dir]:
+        if not os.path.exists(img_dir):
+            img_dir.mkdir(parents=True, exist_ok=True)
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_data.coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -260,8 +260,10 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser, extract
 
     image_shape: Tuple[int, int] = (x_size, y_size)
 
-    os.makedirs(extraction_dir / "float")
-    os.makedirs(extraction_dir / "int")
+    float_peak_dir: Path = Path(extraction_dir) / "float"
+    int_peak_dir: Path = Path(extraction_dir) / "int"
+    os.makedirs(float_peak_dir)
+    os.makedirs(int_peak_dir)
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_data.coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)
@@ -269,8 +271,8 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser, extract
 
         for i_idx, peak in peak_df.loc[peak_df["m/z"].isin(mzs), "peak"].reset_index(drop=True).items():
             img_name: str = f"{peak:.4f}".replace(".", "_")
-            float_peak_path: Path = extraction_dir / "float" / f"{img_name}.tiff"
-            int_peak_path: Path = extraction_dir / "int" / f"{img_name}.tiff"
+            float_peak_path: Path = float_peak_dir / f"{img_name}.tiff"
+            int_peak_path: Path = int_peak_dir / f"{img_name}.tiff"
             peak_exists: bool = os.path.exists(float_peak_path)
             peak_img: np.ndarray = imread(float_peak_path).T if peak_exists else np.zeros(image_shape)
 

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -262,8 +262,10 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser, extract
 
     float_peak_dir: Path = Path(extraction_dir) / "float"
     int_peak_dir: Path = Path(extraction_dir) / "int"
-    os.makedirs(float_peak_dir)
-    os.makedirs(int_peak_dir)
+    if not os.path.exists(float_peak_dir):
+        os.makedirs(float_peak_dir)
+    if not os.path.exists(int_peak_dir):
+        os.makedirs(int_peak_dir)
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_data.coordinates)):
         mzs, intensities = imz_data.getspectrum(idx)

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -12,11 +12,12 @@ import warnings
 from functools import partial
 from operator import itemgetter
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 import xarray as xr
+from alpineer.image_utils import save_image
 from alpineer.io_utils import list_files, remove_file_extensions, validate_paths
 from alpineer.misc_utils import verify_in_list
 from pyimzml.ImzMLParser import ImzMLParser
@@ -78,7 +79,7 @@ def rolling_window(
         total_mass_df (pd.DataFrame): A dataframe containing all the masses and their
             relative intensities.
         intensity_percentile (int): The intensity for the quantile calculation.
-        window_size (int, optional): The sizve of the window for the rolling window method.
+        window_size (int): The sizve of the window for the rolling window method.
             Defaults to 5000.
 
     Returns:
@@ -278,8 +279,8 @@ def coordinate_integration(peak_df: pd.DataFrame, imz_data: ImzMLParser, extract
                 np.uint32
             )
             img_name: str = f"{peak:.4f}".replace(".", "_")
-            image_utils.save_image(fname=extraction_dir / "float" / f"{img_name}.tiff", data=peak_img_float)
-            image_utils.save_image(fname=extraction_dir / "int" / f"{img_name}.tiff", data=peak_img_int)
+            save_image(fname=extraction_dir / "float" / f"{img_name}.tiff", data=peak_img_float)
+            save_image(fname=extraction_dir / "int" / f"{img_name}.tiff", data=peak_img_int)
 
 
 def _matching_vec(obs_mz: pd.Series, library_peak_df: pd.DataFrame, ppm: int) -> pd.Series:
@@ -325,7 +326,7 @@ def library_matching(
         ppm (int): The ppm for an acceptable mass error range between the observed mass and any target
         mass in the library.
         extraction_dir (Path): The directory to save extracted data in.
-        adducts (bool, optional): Add adducts together. Defaults to False. (Not implemented feature)
+        adducts (bool): Add adducts together. Defaults to False. (Not implemented feature)
 
     Returns:
     -------
@@ -334,7 +335,7 @@ def library_matching(
     """
     peak_list: List[float] = [
         float(p.replace("_", "."))
-        for p in io_utils.remove_file_extensions(io_utils.list_files(extraction_dir / "float"))
+        for p in remove_file_extensions(list_files(extraction_dir / "float"))
     ]
     peak_df = pd.DataFrame({"peak": np.array(peak_list)})
     match_fun = partial(_matching_vec, library_peak_df=library_peak_df, ppm=ppm)

--- a/src/maldi_tools/plotting.py
+++ b/src/maldi_tools/plotting.py
@@ -193,18 +193,16 @@ def save_matched_peak_images(
     matched_peaks_df_filtered: pd.DataFrame = matched_peaks_df.dropna()
 
     for row in tqdm(matched_peaks_df_filtered.itertuples(), total=len(matched_peaks_df_filtered)):
-        # load in the corresponding float and integer images
-        float_img: np.ndarray = io.imread(
-            extraction_dir / "float" / f"{str(row.lib_mz).replace('.', '_')}.tiff"
-        )
-        integer_img: np.ndarray = io.imread(
-            extraction_dir / "int" / f"{str(row.lib_mz).replace('.', '_')}.tiff"
-        )
+        if row.matched is True:
+            peak_file_name: str = f"{row.lib_mz:.4f}".replace(".", "_") + ".tiff"
+            # load in the corresponding float and integer images
+            float_img: np.ndarray = io.imread(extraction_dir / "float" / peak_file_name)
+            integer_img: np.ndarray = io.imread(extraction_dir / "int" / peak_file_name)
 
-        img_name: str = row.composition
+            img_name: str = row.composition
 
-        # save floating point image
-        image_utils.save_image(fname=float_dir / f"{img_name}.tiff", data=float_img)
+            # save floating point image
+            image_utils.save_image(fname=float_dir / f"{img_name}.tiff", data=float_img)
 
-        # save integer image
-        image_utils.save_image(fname=int_dir / f"{img_name}.tiff", data=integer_img)
+            # save integer image
+            image_utils.save_image(fname=int_dir / f"{img_name}.tiff", data=integer_img)

--- a/src/maldi_tools/plotting.py
+++ b/src/maldi_tools/plotting.py
@@ -163,13 +163,17 @@ def plot_peak_hist(peak: float, bin_count: int, extraction_dir: Path) -> None:
         extraction_dir (Path): The directory the peak images are saved in
     """
     # verify that the peak provided exists
-    peak_path = extraction_dir / f"{str(peak).replace('.', '_')}.tiff"
+    peak_file: str = f"{peak:.4f}".replace(".", "_")
+    peak_file = peak_file + ".tiff"
+    peak_path = Path(extraction_dir) / "float" / peak_file
     if not os.path.exists(peak_path):
-        raise FileNotFoundError(f"Peak {peak} does not have a corresponding peak image in {extraction_dir}")
+        raise FileNotFoundError(
+            f"Peak {peak:.4f} does not have a corresponding peak image in {extraction_dir}"
+        )
 
     # load the peak image in and display histogram
     peak_img: np.ndarray = io.imread(peak_path)
-    plt.hist(peak_img.values, bins=bin_count)
+    plt.hist(peak_img, bins=bin_count)
 
 
 def save_matched_peak_images(

--- a/src/maldi_tools/plotting.py
+++ b/src/maldi_tools/plotting.py
@@ -184,8 +184,8 @@ def save_matched_peak_images(
         extraction_dir (Path): The directory to save extracted data in.
     """
     # Create image directories if they do not exist
-    float_dir: Path = extraction_dir / "library_matched" / "float"
-    int_dir: Path = extraction_dir / "library_matched" / "int"
+    float_dir: Path = Path(extraction_dir) / "library_matched" / "float"
+    int_dir: Path = Path(extraction_dir) / "library_matched" / "int"
     for img_dir in [float_dir, int_dir]:
         if not os.path.exists(img_dir):
             img_dir.mkdir(parents=True, exist_ok=True)
@@ -196,8 +196,8 @@ def save_matched_peak_images(
         if row.matched is True:
             peak_file_name: str = f"{row.lib_mz:.4f}".replace(".", "_") + ".tiff"
             # load in the corresponding float and integer images
-            float_img: np.ndarray = io.imread(extraction_dir / "float" / peak_file_name)
-            integer_img: np.ndarray = io.imread(extraction_dir / "int" / peak_file_name)
+            float_img: np.ndarray = io.imread(Path(extraction_dir) / "float" / peak_file_name)
+            integer_img: np.ndarray = io.imread(Path(extraction_dir) / "int" / peak_file_name)
 
             img_name: str = row.composition
 

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -433,7 +433,7 @@
    "source": [
     "## Integrate Coordinates\n",
     "\n",
-    "Generate the images and save them in an *xarray*, where the dimensions are: Image (indexed by peak value), $x$, and $y$."
+    "Generate the images and save them as TIFFs in `extraction_dir`. Each file is named after their corresponding peak m/z value, truncated to 4 decimal places. The dimensions of each image correspond to the maximum x- and y-coordinates extracted from the slide."
    ]
   },
   {
@@ -444,7 +444,7 @@
    },
    "outputs": [],
    "source": [
-    "extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data)"
+    "extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data, extraction_dir=extraction_dir)"
    ]
   },
   {
@@ -490,7 +490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Constants"
+    "Set a value for the maximum ppm tolerance between a peak and its corresponding match in the `library_peak_df` specified. Matched peak images are saved as TIFFs to the `library_matched` subfolder inside `extraction_dir` and are named after their matched peak m/z value."
    ]
   },
   {
@@ -677,7 +677,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.10"
   },
   "vscode": {
    "interpreter": {

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -466,18 +466,7 @@
    },
    "outputs": [],
    "source": [
-    "image_data = extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "image_data"
+    "extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data)"
    ]
   },
   {
@@ -509,18 +498,7 @@
    },
    "outputs": [],
    "source": [
-    "image_data.sel(peak=[desired_peak_hist], method=\"nearest\").plot.hist(bins=bin_count)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "plotting.save_peak_images(image_xr=image_data, extraction_dir=extraction_dir)"
+    "plotting.plot_peak_hist(peak=desired_peak_hist, bin_count=bin_count)"
    ]
   },
   {
@@ -557,7 +535,7 @@
    "outputs": [],
    "source": [
     "matched_peaks_df = extraction.library_matching(\n",
-    "    image_xr=image_data, library_peak_df=library_peak_df, ppm=ppm, extraction_dir=extraction_dir\n",
+    "    library_peak_df=library_peak_df, ppm=ppm, extraction_dir=extraction_dir\n",
     ")"
    ]
   },
@@ -570,16 +548,9 @@
    "outputs": [],
    "source": [
     "plotting.save_matched_peak_images(\n",
-    "    image_xr=image_data, matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir\n",
+    "    matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -598,7 +569,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
-from alpineer.io_utils import list_files, list_folders, remove_file_extensions
+from alpineer.io_utils import list_files, remove_file_extensions
 from alpineer.misc_utils import verify_same_elements
 from pyimzml.ImzMLParser import ImzMLParser
 from pytest import TempPathFactory
@@ -104,15 +104,13 @@ def test_coordinate_integration(
     imz_data_coord_int: ImzMLParser,
     peak_widths_coord_int: pd.DataFrame,
     image_xr: xr.DataArray,
-    tmp_path: pathlib.Path
+    tmp_path: pathlib.Path,
 ):
     # peak_df, *_ = peak_widths
     extraction_dir = tmp_path / "extraction_dir"
 
     extraction.coordinate_integration(
-        peak_df=peak_widths_coord_int,
-        imz_data=imz_data_coord_int,
-        extraction_dir=extraction_dir
+        peak_df=peak_widths_coord_int, imz_data=imz_data_coord_int, extraction_dir=extraction_dir
     )
 
     # Make sure the shape of any given image is correct for both float and int

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -103,9 +103,7 @@ def test_peak_spectra(
 def test_coordinate_integration(imz_data, peak_widths, tmp_path: pathlib.Path):
     peak_df, *_ = peak_widths
     extraction_dir = tmp_path / "extraction_dir"
-    extraction.coordinate_integration(
-        peak_df=peak_df, imz_data=imz_data, extraction_dir=extraction_dir
-    )
+    extraction.coordinate_integration(peak_df=peak_df, imz_data=imz_data, extraction_dir=extraction_dir)
 
     # Make sure the shape of any given image is correct.
     test_peak_img = list_files(extraction_dir)[0]
@@ -129,7 +127,9 @@ def test__matching_vec(library: pd.DataFrame, obs_mz: int, true_values: pd.Serie
 
 
 @pytest.mark.parametrize(argnames="_ppm", argvalues=[99])
-def test_library_matching(library: pd.DataFrame, _ppm: int, tmp_path: pathlib.Path):
+def test_library_matching(
+    library: pd.DataFrame, _ppm: image_xr: xr.DataArray, int, tmp_path: pathlib.Path
+):
     extraction_dir = tmp_path / "extraction_dir"
     extraction_dir.mkdir(parents=True, exist_ok=True)
     plotting.save_peak_images(image_xr, extraction_dir)

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -128,7 +128,7 @@ def test__matching_vec(library: pd.DataFrame, obs_mz: int, true_values: pd.Serie
 
 @pytest.mark.parametrize(argnames="_ppm", argvalues=[99])
 def test_library_matching(
-    library: pd.DataFrame, _ppm: image_xr: xr.DataArray, int, tmp_path: pathlib.Path
+    library: pd.DataFrame, image_xr: xr.DataArray, _ppm: int, tmp_path: pathlib.Path
 ):
     extraction_dir = tmp_path / "extraction_dir"
     extraction_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -127,9 +127,7 @@ def test__matching_vec(library: pd.DataFrame, obs_mz: int, true_values: pd.Serie
 
 
 @pytest.mark.parametrize(argnames="_ppm", argvalues=[99])
-def test_library_matching(
-    library: pd.DataFrame, image_xr: xr.DataArray, _ppm: int, tmp_path: pathlib.Path
-):
+def test_library_matching(library: pd.DataFrame, image_xr: xr.DataArray, _ppm: int, tmp_path: pathlib.Path):
     extraction_dir = tmp_path / "extraction_dir"
     extraction_dir.mkdir(parents=True, exist_ok=True)
     plotting.save_peak_images(image_xr, extraction_dir)

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -89,9 +89,7 @@ def test_save_matched_peak_images(rng: np.random.Generator, image_xr: xr.DataArr
 
     matched_peaks_df = pd.DataFrame(data={"composition": rng.random(size=(3,))})
 
-    plotting.save_matched_peak_images(
-        matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir
-    )
+    plotting.save_matched_peak_images(matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir)
 
     for peak in matched_peaks_df.itertuples():
         # Assert that the float and integer images are saved.

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -87,11 +87,41 @@ def test_save_matched_peak_images(rng: np.random.Generator, image_xr: xr.DataArr
     extraction_dir.mkdir(parents=True, exist_ok=True)
     plotting.save_peak_images(image_xr, extraction_dir)
 
-    matched_peaks_df = pd.DataFrame(data={"composition": rng.random(size=(3,))})
+    peaks = image_xr.peak.values
+    img_shape = (image_xr.shape[1], image_xr.shape[2])
+    matched = [False] * len(peaks)
+    matched[-1] = True
+    composition = [np.nan] * len(peaks)
+    composition[-1] = rng.random(size=(1,))
+    mass_error = [np.nan] * len(peaks)
+    mass_error[-1] = rng.random(size=(1,))
+    matched_peaks_df = pd.DataFrame(
+        data={
+            "lib_mz": peaks,
+            "matched": matched,
+            "composition": composition,
+            "mass_error": mass_error,
+        }
+    )
 
     plotting.save_matched_peak_images(matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir)
 
     for peak in matched_peaks_df.itertuples():
-        # Assert that the float and integer images are saved.
-        assert os.path.exists(extraction_dir / "library_matched" / "float" / f"{peak.composition}.tiff")
-        assert os.path.exists(extraction_dir / "library_matched" / "int" / f"{peak.composition}.tiff")
+        float_peak_path = extraction_dir / "library_matched" / "float" / f"{peak.composition}.tiff"
+        int_peak_path = extraction_dir / "library_matched" / "int" / f"{peak.composition}.tiff"
+
+        # Assert that the float and integer images are saved for all matched peaks.
+        # Check that the peak images match the desired shape
+        if peak.matched is True:
+            assert os.path.exists(float_peak_path)
+            assert os.path.exists(int_peak_path)
+
+            matched_float_img = imread(float_peak_path)
+            matched_int_img = imread(int_peak_path)
+
+            assert matched_float_img.shape == img_shape
+            assert matched_int_img.shape == img_shape
+        # Otherwise, ensure peaks are not saved
+        else:
+            assert not os.path.exists(float_peak_path)
+            assert not os.path.exists(int_peak_path)

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -85,11 +85,12 @@ def test_save_peak_images(image_xr: xr.DataArray, tmp_path: pathlib.Path):
 def test_save_matched_peak_images(rng: np.random.Generator, image_xr: xr.DataArray, tmp_path: pathlib.Path):
     extraction_dir = tmp_path / "extraction_dir"
     extraction_dir.mkdir(parents=True, exist_ok=True)
+    plotting.save_peak_images(image_xr, extraction_dir)
 
     matched_peaks_df = pd.DataFrame(data={"composition": rng.random(size=(3,))})
 
     plotting.save_matched_peak_images(
-        image_xr=image_xr, matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir
+        matched_peaks_df=matched_peaks_df, extraction_dir=extraction_dir
     )
 
     for peak in matched_peaks_df.itertuples():

--- a/tests/plotting_test.py
+++ b/tests/plotting_test.py
@@ -5,6 +5,7 @@ import pathlib
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 from skimage.io import imread
 
@@ -80,6 +81,23 @@ def test_save_peak_images(image_xr: xr.DataArray, tmp_path: pathlib.Path):
 
         iname = extraction_dir / "int" / f"{peak:.4f}.tiff".replace(".", "_", 1)
         assert os.path.exists(iname)
+
+
+def test_plot_peak_hist(image_xr: xr.DataArray, tmp_path: pathlib.Path):
+    extraction_dir = tmp_path / "extraction_dir"
+    extraction_dir.mkdir(parents=True, exist_ok=True)
+
+    # ensure the test actually truncates to 4 digits correctly
+    image_xr = image_xr.assign_coords(peak=np.random.rand(6) * 100)
+
+    plotting.save_peak_images(image_xr=image_xr, extraction_dir=extraction_dir)
+
+    # this test should run to completion, since the peak can be loaded
+    plotting.plot_peak_hist(peak=image_xr.peak.values[0], bin_count=30, extraction_dir=extraction_dir)
+
+    # this test should fail since the peak does not exist
+    with pytest.raises(FileNotFoundError):
+        plotting.plot_peak_hist(peak=50.0123, bin_count=30, extraction_dir=extraction_dir)
 
 
 def test_save_matched_peak_images(rng: np.random.Generator, image_xr: xr.DataArray, tmp_path: pathlib.Path):


### PR DESCRIPTION
**What is the purpose of this PR?**

With 1000+ peak images, keeping them all stored in memory is infeasible. They should be saved and loaded in on an individual basis.

**How did you implement your changes**

This will change the peak image workflow. Currently, they're all housed in a single in-memory `xarray`. Instead:

1. In `extraction.coordinate_integration`, save the peak images directly instead of storing them in the `xarray`. This will replace the functionality in `plotting.save_peak_images`
2. Add a function `plotting.plot_peak_hist` to replace the notebook cell `image_data.sel(peak=[desired_peak_hist], method="nearest").plot.hist(bins=bin_count)`
3. Update `extraction.library_matching` to use `io_utils.list_files` to retrieve the peak values instead of using the `xarray` dimension
4. Change `plotting.save_matched_peak_images` to load the matched peak image from `extraction_dir` instead of indexing into the `xarray` directly

**Remaining issues**

Ongoing testing, full testing suite still needs to be implemented.