### PR TITLE
Add Jupyter module extensions for navigation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,9 @@ dependencies:
   - python=3.11
   - pip
   - jupyterlab
+  - jupyterlab-lsp
+  - jupyterlab-git
+  - jupyterlab_execute_time
   - ipywidgets
   - tqdm
   - numpy


### PR DESCRIPTION
**What is the purpose of this PR?**

Adds a few Jupyter modules used in other `angelolab` repos that provide more interactivity in the notebooks.

**How did you implement your changes**

The libraries included are:

- `jupyterlab-lsp`
- `jupyterlab-git`
- `jupyterlab_execute_time`