### PR TITLE
Fix location of `intensity_percentile` variable setting in notebook

### DIFF
--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -180,13 +180,15 @@
     "# define the .imzml/.ibd loader object\n",
     "imz_data = ImzMLParser(imzml_path, include_spectra_metadata=\"full\")\n",
     "\n",
+    "# define the intensity percentile\n",
+    "intensity_percentile = 99\n",
+    "\n",
     "# extract the spectra and threshold array\n",
     "total_mass_df, thresholds = extraction.extract_spectra(\n",
     "    imz_data=imz_data, intensity_percentile=intensity_percentile\n",
     ")\n",
     "\n",
     "# define the global intensity threshold\n",
-    "intensity_percentile = 99\n",
     "global_intensity_threshold = np.percentile(total_mass_df[\"intensity\"].values, intensity_percentile)\n",
     "print(f\"Global Intensity Threshold: {global_intensity_threshold}\")\n",
     "\n",
@@ -649,7 +651,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**What is the purpose of this PR?**

The `intensity_percentile` variable in the notebook is currently defined after its first actual usage. This PR fixes it.