### PR TITLE
Update extraction pipeline to per-region as opposed to aggregate

### DIFF
--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -72,13 +72,19 @@ def extract_spectra(
         skiprows=1,
     )
     poslog_data_sub = poslog_data[poslog_data["Region"] != "__"].copy()
+    poslog_data_sub["Region"] = poslog_data_sub["Region"].str.extract(r"R(\d+)X", expand=False).astype(int)
+    coords: np.ndarray = np.array([coord[:2] for coord in imz_coordinates])
+    coords_subset: np.ndarray = coords[: poslog_data_sub.shape[0], :]
+    poslog_data_sub[["X", "Y"]] = coords_subset
+
+    if region_num > poslog_data_sub["Region"].max():
+        raise ValueError("Region num out of range")
+
     poslog_data_sub = (
         poslog_data_sub[poslog_data_sub["Region"] == region_num].copy()
-        if region_num
+        if region_num is not None
         else poslog_data_sub.copy()
     )
-    extracted_regions: pd.Series = poslog_data_sub["Region"].str.extract(r"R(\d+)X", expand=False).astype(int)
-    poslog_data_sub["Region"] = extracted_regions
 
     thresholds: np.ndarray = np.zeros(image_shape)
     total_spectra: Dict[float, float] = {}

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -27,11 +27,43 @@ from tqdm.notebook import tqdm
 from maldi_tools import plotting
 
 
+def load_poslog(
+    poslog_path: Union[str, Path],
+    imz_data: ImzMLParser,
+) -> pd.DataFrame:
+    """Loads and processes the poslog region info and harmonizes it with the imzML coordinate data.
+
+    Args:
+    ----
+        poslog_path (Union[str, Path]): the associated poslog path
+        imz_data (ImzMLParser): The imzML object
+
+    Returns:
+    -------
+        pd.DataFrame: A DataFrame listing each coordinate and its corresponding region
+    """
+    poslog_data = pd.read_csv(
+        poslog_path,
+        delimiter=" ",
+        names=["Date", "Time", "Region", "PosX", "PosY", "X", "Y", "Z"],
+        usecols=["Region", "X", "Y"],
+        index_col=False,
+        skiprows=1,
+    )
+    poslog_data = poslog_data[poslog_data["Region"] != "__"].copy()
+    poslog_data["Region"] = poslog_data["Region"].str.extract(r"R(\d+)X", expand=False).astype(int)
+    coords: np.ndarray = np.array([coord[:2] for coord in imz_data.coordinates])
+    coords_subset: np.ndarray = coords[: poslog_data.shape[0], :]
+    poslog_data[["X", "Y"]] = coords_subset
+
+    return poslog_data
+
+
 def extract_spectra(
     imz_data: ImzMLParser,
     intensity_percentile: int,
     region_num: Optional[int] = None,
-    poslog_path: Optional[Union[str, Path]] = None,
+    poslog_data: pd.DataFrame = None,
 ) -> tuple[pd.DataFrame, np.ndarray]:
     """Iterates over all coordinates after opening the `imzML` data and extracts all masses,
     and sums the intensities for all masses. Creates an intensity image, thresholded on
@@ -41,9 +73,9 @@ def extract_spectra(
     ----
         imz_data (ImzMLParser): The imzML object.
         intensity_percentile (int): Used to compute the q-th percentile of the intensities.
-        region (Optional[int]): the specific region to load, requires an associated poslog file
-        poslog_path (Optional[Union[str, pathlib.Path]]): the associated poslog path, ignored if
-            region is None
+        region (Optional[int]): The specific region to load, requires an associated poslog file
+        poslog_path (Optional[Union[str, pathlib.Path]]): The associated poslog region and
+            coordinate data
 
     Returns:
     -------
@@ -51,9 +83,9 @@ def extract_spectra(
         the total masses and their intensities, and the second element is the thresholds matrix
         of the image.
     """
-    if region_num and not poslog_path:
+    if region_num and not poslog_data:
         raise ValueError(
-            "If region_num set, an associated poslog_path must also be passed so coordinates can be"
+            "If region_num set, an associated poslog_data must also be passed so coordinates can be"
             " identified"
         )
     imz_coordinates: list = imz_data.coordinates
@@ -63,27 +95,13 @@ def extract_spectra(
 
     image_shape: Tuple[int, int] = (x_size, y_size)
 
-    poslog_data = pd.read_csv(
-        poslog_path,
-        delimiter=" ",
-        names=["Date", "Time", "Region", "PosX", "PosY", "X", "Y", "Z"],
-        usecols=["Region", "X", "Y"],
-        index_col=False,
-        skiprows=1,
-    )
-    poslog_data_sub = poslog_data[poslog_data["Region"] != "__"].copy()
-    poslog_data_sub["Region"] = poslog_data_sub["Region"].str.extract(r"R(\d+)X", expand=False).astype(int)
-    coords: np.ndarray = np.array([coord[:2] for coord in imz_coordinates])
-    coords_subset: np.ndarray = coords[: poslog_data_sub.shape[0], :]
-    poslog_data_sub[["X", "Y"]] = coords_subset
-
-    if region_num > poslog_data_sub["Region"].max():
+    if region_num > poslog_data["Region"].max():
         raise ValueError("Region num out of range")
 
     poslog_data_sub = (
-        poslog_data_sub[poslog_data_sub["Region"] == region_num].copy()
+        poslog_data[poslog_data["Region"] == region_num].copy()
         if region_num is not None
-        else poslog_data_sub.copy()
+        else poslog_data.copy()
     )
 
     thresholds: np.ndarray = np.zeros(image_shape)

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -73,7 +73,9 @@ def extract_spectra(
     )
     poslog_data_sub = poslog_data[poslog_data["Region"] != "__"].copy()
     poslog_data_sub = (
-        poslog_data[poslog_data["Region"] == region_num].copy() if region_num else poslog_data.copy()
+        poslog_data_sub[poslog_data_sub["Region"] == region_num].copy()
+        if region_num
+        else poslog_data_sub.copy()
     )
     extracted_regions: pd.Series = poslog_data_sub["Region"].str.extract(r"R(\d+)X", expand=False).astype(int)
     poslog_data_sub["Region"] = extracted_regions

--- a/src/maldi_tools/extraction.py
+++ b/src/maldi_tools/extraction.py
@@ -12,7 +12,7 @@ import warnings
 from functools import partial
 from operator import itemgetter
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -27,7 +27,12 @@ from tqdm.notebook import tqdm
 from maldi_tools import plotting
 
 
-def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[pd.DataFrame, np.ndarray]:
+def extract_spectra(
+    imz_data: ImzMLParser,
+    intensity_percentile: int,
+    region_num: Optional[int] = None,
+    poslog_path: Optional[Union[str, Path]] = None,
+) -> tuple[pd.DataFrame, np.ndarray]:
     """Iterates over all coordinates after opening the `imzML` data and extracts all masses,
     and sums the intensities for all masses. Creates an intensity image, thresholded on
     `intensity_percentile` with `np.percentile`. The masses are then sorted.
@@ -36,6 +41,9 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
     ----
         imz_data (ImzMLParser): The imzML object.
         intensity_percentile (int): Used to compute the q-th percentile of the intensities.
+        region (Optional[int]): the specific region to load, requires an associated poslog file
+        poslog_path (Optional[Union[str, pathlib.Path]]): the associated poslog path, ignored if
+            region is None
 
     Returns:
     -------
@@ -43,6 +51,11 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
         the total masses and their intensities, and the second element is the thresholds matrix
         of the image.
     """
+    if region_num and not poslog_path:
+        raise ValueError(
+            "If region_num set, an associated poslog_path must also be passed so coordinates can be"
+            " identified"
+        )
     imz_coordinates: list = imz_data.coordinates
 
     x_size: int = max(imz_coordinates, key=itemgetter(0))[0]
@@ -50,15 +63,33 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
 
     image_shape: Tuple[int, int] = (x_size, y_size)
 
+    poslog_data = pd.read_csv(
+        poslog_path,
+        delimiter=" ",
+        names=["Date", "Time", "Region", "PosX", "PosY", "X", "Y", "Z"],
+        usecols=["Region", "X", "Y"],
+        index_col=False,
+        skiprows=1,
+    )
+    poslog_data_sub = poslog_data[poslog_data["Region"] != "__"].copy()
+    poslog_data_sub = (
+        poslog_data[poslog_data["Region"] == region_num].copy() if region_num else poslog_data.copy()
+    )
+    extracted_regions: pd.Series = poslog_data_sub["Region"].str.extract(r"R(\d+)X", expand=False).astype(int)
+    poslog_data_sub["Region"] = extracted_regions
+
     thresholds: np.ndarray = np.zeros(image_shape)
     total_spectra: Dict[float, float] = {}
 
     for idx, (x, y, _) in tqdm(enumerate(imz_data.coordinates), total=len(imz_coordinates)):
-        mzs, intensities = imz_data.getspectrum(idx)
-        for mass_idx, mz in enumerate(mzs):
-            total_spectra[mz] = (0 if mz not in total_spectra else total_spectra[mz]) + intensities[mass_idx]
+        if x in poslog_data_sub["X"].values and y in poslog_data_sub["Y"].values:
+            mzs, intensities = imz_data.getspectrum(idx)
+            for mass_idx, mz in enumerate(mzs):
+                total_spectra[mz] = (0 if mz not in total_spectra else total_spectra[mz]) + intensities[
+                    mass_idx
+                ]
 
-        thresholds[x - 1, y - 1] = np.percentile(intensities, intensity_percentile)
+            thresholds[x - 1, y - 1] = np.percentile(intensities, intensity_percentile)
 
     total_mass_df = pd.DataFrame(total_spectra.items(), columns=["m/z", "intensity"])
 
@@ -69,7 +100,7 @@ def extract_spectra(imz_data: ImzMLParser, intensity_percentile: int) -> tuple[p
 
 
 def rolling_window(
-    total_mass_df: pd.DataFrame, intensity_percentile: int, window_size: int = 5000
+    total_mass_df: pd.DataFrame, intensity_percentile: int, window_size: Optional[int] = 5000
 ) -> tuple[np.ndarray, np.ndarray]:
     """Computes the rolling window log intensities and the rolling window log intensity percentiles.
 
@@ -78,7 +109,7 @@ def rolling_window(
         total_mass_df (pd.DataFrame): A dataframe containing all the masses and their
             relative intensities.
         intensity_percentile (int): The intensity for the quantile calculation.
-        window_size (int, optional): The sizve of the window for the rolling window method.
+        window_size (Optional[int]): The sizve of the window for the rolling window method.
             Defaults to 5000.
 
     Returns:
@@ -316,7 +347,7 @@ def library_matching(
     library_peak_df: pd.DataFrame,
     ppm: int,
     extraction_dir: Path,
-    adducts: bool = False,
+    adducts: Optional[bool] = False,
 ) -> pd.DataFrame:
     """Matches the image peaks to the library, and creates a csv which contains the library target masses,
     and their associated peaks found in the data file, if they match within a tolerance.
@@ -328,7 +359,7 @@ def library_matching(
         ppm (int): The ppm for an acceptable mass error range between the observed mass and any target
         mass in the library.
         extraction_dir (Path): The directory to save extracted data in.
-        adducts (bool, optional): Add adducts together. Defaults to False. (Not implemented feature)
+        adducts (Optional[bool]): Add adducts together. Defaults to False. (Not implemented feature)
 
     Returns:
     -------

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -149,13 +149,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -180,25 +173,39 @@
     "# define the .imzml/.ibd loader object\n",
     "imz_data = ImzMLParser(imzml_path, include_spectra_metadata=\"full\")\n",
     "\n",
-    "# extract the spectra and threshold array\n",
-    "total_mass_df, thresholds = extraction.extract_spectra(\n",
-    "    imz_data=imz_data, intensity_percentile=intensity_percentile\n",
-    ")\n",
+    "# extract the spectra and threshold array, mapped from region num to extracted data\n",
+    "total_mass_dfs = {}\n",
+    "thresholds = {}\n",
     "\n",
-    "# define the global intensity threshold\n",
+    "region_num = 0\n",
+    "while True:\n",
+    "    try:\n",
+    "        total_mass_df, thresholds = extraction.extract_spectra(\n",
+    "            imz_data=imz_data, intensity_percentile=intensity_percentile\n",
+    "        )\n",
+    "        total_mass_dfs[region_num] = total_mass_df\n",
+    "        thresholds[region_num] = thresholds\n",
+    "        region_num += 1\n",
+    "    except Exception as e:\n",
+    "        break\n",
+    "\n",
+    "# define the global intensity threshold, this should be the same across all regions\n",
     "intensity_percentile = 99\n",
-    "global_intensity_threshold = np.percentile(total_mass_df[\"intensity\"].values, intensity_percentile)\n",
-    "print(f\"Global Intensity Threshold: {global_intensity_threshold}\")\n",
+    "global_intensity_thresholds = {\n",
+    "    rn: np.percentile(tmd[\"intensity\"].values, intensity_percentile) for (rn, tmd) in total_mass_dfs.items()\n",
+    "}\n",
+    "print(f\"Global Intensity Thresholds: {global_intensity_thresholds}\")\n",
     "\n",
-    "# display the format and the top few peaks extracted\n",
-    "display(total_mass_df.head())"
+    "# display the format and the top few peaks extracted for a region\n",
+    "region_num = 0\n",
+    "display(total_mass_dfs[region_num].head())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For additional verification, set `largest_intensity_count` to see the `n` largest intensities."
+    "For additional verification, set `largest_intensity_count` to see the `n` largest intensities for a specific `region_num`."
    ]
   },
   {
@@ -207,8 +214,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "region_num = 0\n",
     "largest_intensity_count = 10\n",
-    "total_mass_df.nlargest(largest_intensity_count, [\"intensity\"])"
+    "\n",
+    "total_mass_dfs[region_num].nlargest(largest_intensity_count, [\"intensity\"])"
    ]
   },
   {
@@ -256,16 +265,22 @@
    },
    "outputs": [],
    "source": [
-    "log_intensities, log_int_percentile = extraction.rolling_window(\n",
-    "    total_mass_df=total_mass_df, intensity_percentile=intensity_percentile, window_size=5000\n",
-    ")"
+    "log_intensity_vals = {}\n",
+    "log_int_percentiles = {}\n",
+    "\n",
+    "for region_num in total_mass_dfs:\n",
+    "    log_intensities, log_int_percentile = extraction.rolling_window(\n",
+    "        total_mass_df=total_mass_dfs[region_num], intensity_percentile=intensity_percentile, window_size=5000\n",
+    "    )\n",
+    "    log_intensity_vals[region_num] = log_intensities\n",
+    "    log_int_percentiles[region_num] = log_int_percentile"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visualizes how the thresholds you chose affect the peak candidates identified."
+    "Visualizes how the thresholds you chose affect the peak candidates identified for a specific region."
    ]
   },
   {
@@ -276,11 +291,13 @@
    },
    "outputs": [],
    "source": [
+    "region_num = 0\n",
+    "\n",
     "plotting.plot_intensities(\n",
-    "    total_mass_df=total_mass_df,\n",
-    "    log_intensities=log_intensities,\n",
-    "    log_int_percentile=log_int_percentile,\n",
-    "    global_intensity_threshold=global_intensity_threshold,\n",
+    "    total_mass_df=total_mass_dfs[region_num],\n",
+    "    log_intensities=log_intensities[region_num],\n",
+    "    log_int_percentile=log_int_percentile[region_num],\n",
+    "    global_intensity_threshold=global_intensity_thresholds[region_num],\n",
     ")"
    ]
   },
@@ -304,18 +321,24 @@
    },
    "outputs": [],
    "source": [
-    "peak_candidate_idxs, peak_candidates = extraction.signal_extraction(\n",
-    "    total_mass_df=total_mass_df, log_int_percentile=log_int_percentile\n",
-    ")\n",
+    "peak_candidate_idx_vals = {}\n",
+    "peak_candidate_vals = {}\n",
     "\n",
-    "print(f\"Candiate Peak Count: {len(peak_candidates)}\")"
+    "for region_num in total_mass_dfs:\n",
+    "    peak_candidate_idxs, peak_candidates = extraction.signal_extraction(\n",
+    "        total_mass_df=total_mass_dfs[region_num], log_int_percentile=log_int_percentiles[region_num]\n",
+    "    )\n",
+    "    peak_candidate_idx_vals[region_num] = peak_candidate_idxs\n",
+    "    peak_candidate_vals[region_num] = peak_candidates\n",
+    "    \n",
+    "    print(f\"Candiate Peak Count for Region {region_num}: {len(peak_candidates)}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visualize the discovered peaks."
+    "Visualize the discovered peaks for a region."
    ]
   },
   {
@@ -326,11 +349,13 @@
    },
    "outputs": [],
    "source": [
+    "region_num = 0\n",
+    "\n",
     "plotting.plot_discovered_peaks(\n",
-    "    total_mass_df=total_mass_df,\n",
-    "    peak_candidate_idxs=peak_candidate_idxs,\n",
-    "    peak_candidates=peak_candidates,\n",
-    "    global_intensity_threshold=global_intensity_threshold,\n",
+    "    total_mass_df=total_mass_dfs[region_num],\n",
+    "    peak_candidate_idxs=peak_candidate_idx_vals[region_num],\n",
+    "    peak_candidates=peak_candidate_vals[region_num],\n",
+    "    global_intensity_threshold=global_intensity_thresholds[region_num],\n",
     ")"
    ]
   },
@@ -649,7 +674,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.10.15"
   },
   "vscode": {
    "interpreter": {

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -123,6 +123,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Finally, set the poslog path, this is a separate metadata file that defines the coordinates associated with each region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poslog_path = \"/path/to/poslog.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 1.2. Plotting parameters\n",
     "\n",
     "Define the pltoting parameters."
@@ -181,7 +197,10 @@
     "while True:\n",
     "    try:\n",
     "        total_mass_df, thresholds = extraction.extract_spectra(\n",
-    "            imz_data=imz_data, intensity_percentile=intensity_percentile\n",
+    "            imz_data=imz_data,\n",
+    "            intensity_percentile=intensity_percentile,\n",
+    "            region_num=region_num,\n",
+    "            poslog_path=poslog_path,\n",
     "        )\n",
     "        total_mass_dfs[region_num] = total_mass_df\n",
     "        thresholds[region_num] = thresholds\n",

--- a/templates/maldi-pipeline.ipynb
+++ b/templates/maldi-pipeline.ipynb
@@ -123,7 +123,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, set the poslog path, this is a separate metadata file that defines the coordinates associated with each region."
+    "Finally, set the poslog path, this is a separate metadata file that defines the coordinates associated with each region.\n",
+    "\n",
+    "**NOTE**: if you will be processing the full cohort and do not need the poslog info, set to `None`."
    ]
   },
   {
@@ -132,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "poslog_path = \"/path/to/poslog.txt"
+    "poslog_path = \"/path/to/poslog.txt\""
    ]
   },
   {
@@ -170,12 +172,45 @@
    "source": [
     "## 2. Data Loading\n",
     "\n",
+    "### 2.0. Define globals\n",
+    "\n",
+    "Load in the following global data loaders/datasets:\n",
+    "* `imz_data`: a loader object used to read the MALDI spectra and coordinate info\n",
+    "* `poslog_data`: a table containing each coordinate's corresponding region\n",
+    "* `intensity_percentile`: the percentile to use for defining MALDI thresholds\n",
+    "* `per_region`: set to `False` if you want to extract the full cohort aggregating all the regions together"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the .imzml/.ibd loader object\n",
+    "imz_data = ImzMLParser(imzml_path, include_spectra_metadata=\"full\")\n",
+    "\n",
+    "# define the poslog data\n",
+    "poslog_data = extraction.load_poslog(poslog_path, imz_data)\n",
+    "\n",
+    "# define the global intensity threshold, this should be the same across all regions\n",
+    "intensity_percentile = 99\n",
+    "\n",
+    "# define per-region or full-aggregate analysis\n",
+    "per_region = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 2.1. Spectra\n",
     "\n",
     "Load in the spectra information defined by the `.imzml`/`.ibd` file. The following variables are extracted:\n",
     "\n",
     "* `total_mass_df`: tabulates every m/z value found along with their corresponding intensity (summed across all pixels).\n",
-    "* `thresholds`: defines the nth intensity value (defined by `intensity_percentile`, computed across all m/z values) found across each pixel."
+    "* `thresholds`: defines the nth intensity value (defined by `intensity_percentile`, computed across all m/z values) found across each pixel.\n",
+    "* `global_intensity_thresholds`: the value for each region used for thresholding"
    ]
   },
   {
@@ -186,37 +221,52 @@
    },
    "outputs": [],
    "source": [
-    "# define the .imzml/.ibd loader object\n",
-    "imz_data = ImzMLParser(imzml_path, include_spectra_metadata=\"full\")\n",
-    "\n",
     "# extract the spectra and threshold array, mapped from region num to extracted data\n",
     "total_mass_dfs = {}\n",
     "thresholds = {}\n",
     "\n",
-    "region_num = 0\n",
-    "while True:\n",
-    "    try:\n",
+    "if per_region:\n",
+    "    num_regions = poslog_data[\"Region\"].max()\n",
+    "    for region in range(num_regions + 1):\n",
     "        total_mass_df, thresholds = extraction.extract_spectra(\n",
     "            imz_data=imz_data,\n",
     "            intensity_percentile=intensity_percentile,\n",
-    "            region_num=region_num,\n",
-    "            poslog_path=poslog_path,\n",
+    "            region_num=region,\n",
+    "            poslog_data=poslog_data,\n",
     "        )\n",
-    "        total_mass_dfs[region_num] = total_mass_df\n",
-    "        thresholds[region_num] = thresholds\n",
-    "        region_num += 1\n",
-    "    except Exception as e:\n",
-    "        break\n",
+    "        total_mass_dfs[region] = total_mass_df\n",
+    "        thresholds[region] = thresholds\n",
+    "else:\n",
+    "    total_mass_df, thresholds = extraction.extract_spectra(\n",
+    "        imz_data=imz_data,\n",
+    "        intensity_percentile=intensity_percentile,\n",
+    "        region_num=None,\n",
+    "        poslog_data=poslog_data,\n",
+    "    )\n",
+    "    total_mass_dfs[\"all\"] = total_mass_df\n",
+    "    thresholds[\"all\"] = thresholds\n",
     "\n",
-    "# define the global intensity threshold, this should be the same across all regions\n",
-    "intensity_percentile = 99\n",
     "global_intensity_thresholds = {\n",
     "    rn: np.percentile(tmd[\"intensity\"].values, intensity_percentile) for (rn, tmd) in total_mass_dfs.items()\n",
-    "}\n",
-    "print(f\"Global Intensity Thresholds: {global_intensity_thresholds}\")\n",
-    "\n",
-    "# display the format and the top few peaks extracted for a region\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the intensity thresholds for and top peaks for a specific region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "region_num = 0\n",
+    "\n",
+    "print(f\"Global Intensity Thresholds: {global_intensity_thresholds[region_num]}\")\n",
     "display(total_mass_dfs[region_num].head())"
    ]
   },
@@ -395,12 +445,23 @@
    },
    "outputs": [],
    "source": [
-    "peak_df, l_ips_r, r_ips_r, peak_widths_height = extraction.get_peak_widths(\n",
-    "    total_mass_df=total_mass_df,\n",
-    "    peak_candidate_idxs=peak_candidate_idxs,\n",
-    "    peak_candidates=peak_candidates,\n",
-    "    thresholds=thresholds,\n",
-    ")"
+    "peak_dfs = {}\n",
+    "l_ips_r_vals = {}\n",
+    "r_ips_r_vals = {}\n",
+    "peak_widths_heights = {}\n",
+    "\n",
+    "for region_num in total_mass_dfs:\n",
+    "    peak_df, l_ips_r, r_ips_r, peak_widths_height = extraction.get_peak_widths(\n",
+    "        total_mass_df=total_mass_dfs[region_num],\n",
+    "        peak_candidate_idxs=peak_candidate_idx_vals[region_num],\n",
+    "        peak_candidates=peak_candidate_vals[region_num],\n",
+    "        thresholds=thresholds[region_num],\n",
+    "    )\n",
+    "\n",
+    "    peak_dfs[region_num] = peak_df\n",
+    "    l_ips_r_vals[region_num] = l_ips_r\n",
+    "    r_ips_r_vals[region_num] = r_ips_r\n",
+    "    peak_widths_heights[region_num] = peak_widths_height"
    ]
   },
   {
@@ -423,20 +484,39 @@
    "outputs": [],
    "source": [
     "save_peak_spectra_debug = True\n",
+    "panel_dfs = {}\n",
     "\n",
-    "panel_df = extraction.peak_spectra(\n",
-    "    total_mass_df=total_mass_df,\n",
-    "    peak_df=peak_df,\n",
-    "    peak_candidate_idxs=peak_candidate_idxs,\n",
-    "    peak_candidates=peak_candidates,\n",
-    "    peak_widths_height=peak_widths_height,\n",
-    "    l_ips_r=l_ips_r,\n",
-    "    r_ips_r=r_ips_r,\n",
-    "    save_peak_spectra_debug=save_peak_spectra_debug,\n",
-    "    debug_dir=debug_dir,\n",
-    ")\n",
+    "for region_num in total_mass_dfs\n",
+    "    panel_df = extraction.peak_spectra(\n",
+    "        total_mass_df=total_mass_dfs[region_num],\n",
+    "        peak_df=peak_dfs[region_num],\n",
+    "        peak_candidate_idxs=peak_candidate_idx_vals[region_num],\n",
+    "        peak_candidates=peak_candidate_vals[region_num],\n",
+    "        peak_widths_height=peak_widths_heights[region_num],\n",
+    "        l_ips_r=l_ips_r_vals[region_num],\n",
+    "        r_ips_r=r_ips_r_vals[region_num],\n",
+    "        save_peak_spectra_debug=save_peak_spectra_debug,\n",
+    "        debug_dir=debug_dir,\n",
+    "    )\n",
+    "    panel_dfs[region_num] = panel_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the top few peaks for a specific region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region_num = 0\n",
     "\n",
-    "display(panel_df.head())"
+    "display(panel_dfs[region_num].head())"
    ]
   },
   {
@@ -693,7 +773,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.11.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**What is the purpose of this PR?**

An entire MALDI dataset across a whole TMA is extremely expensive to extract and analyze. To improve efficiency, we update the pipeline to run on a per-region basis.

**How did you implement your changes**

We use the poslog to identify which coordinate belongs to which region. This is similar to the workflow for the core cropping step. By specifying a `region_num` param during the extraction process, we can exclude coordinates outside the region of interest.

**Remaining issues**

Potential improvements
1. Include a param in the extraction step to automatically generate all regions in a single pass, as opposed to looping the whole .imzML for each region.
2. Include options for smaller subsets of pixels. This will be useful for tissue samples.